### PR TITLE
Simplify cors setup when running development server

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,7 @@ export data_dir
 run-devel:
 	cd server \
 	&& MOVICI_FLOW_DATA_DIR=$(data_dir) \
+	   MOVICI_FLOW_ALLOW_CORS=1 \
 	   poetry run uvicorn --factory movici_viewer.main:get_app --host localhost --port 5000 --reload
 
 run:

--- a/README.md
+++ b/README.md
@@ -79,13 +79,11 @@ make run-devel
 ```
 
 Then, change the `"baseURL"` in `client/public/static/settings/settings.json` to the address of
-the local development server, eg: `"http://localhost:5000`. Be sure **NOT** to commit this change.
+the local development server, eg: `"http://localhost:5000/"`. Be sure **NOT** to commit this change.
 
-Then, in a separate terminal run.
+Then, in a separate terminal run the following command:
 
 ```
-npm run --prefix client serve
+npm run --prefix client dev
 ```
 
-In order to succesfully connect to the local api server, you may need to use and activate a CORS
-browser plugin.

--- a/server/movici_viewer/main.py
+++ b/server/movici_viewer/main.py
@@ -10,23 +10,25 @@ from starlette.responses import RedirectResponse
 
 from .dependencies import get_settings
 from .exceptions import add_exception_handling
-from .routers import scenario_router, dataset_router, update_router, view_router
+from .routers import dataset_router, scenario_router, update_router, view_router
 from .settings import Settings
 
 __UI_DIR__ = Path(__file__).parent / "ui"
 
 
-def get_app(settings: t.Optional[Settings] = None, mount_ui=True, allow_cors=False):
+def get_app(settings: t.Optional[Settings] = None, mount_ui=True):
     app = FastAPI()
     if settings is not None:
         app.dependency_overrides[get_settings] = lambda: settings
+    else:
+        settings = get_settings()
     app.include_router(scenario_router)
     app.include_router(dataset_router)
     app.include_router(update_router)
     app.include_router(view_router)
     if mount_ui:
         add_ui(app)
-    if allow_cors:
+    if settings.ALLOW_CORS:
         setup_cors(app)
     add_exception_handling(app)
     return app
@@ -55,6 +57,6 @@ def setup_cors(app: FastAPI):
 @click.option("--port", "-p", default=5000)
 @click.option("--allow-cors", is_flag=True, default=False)
 def main(directory, host, port, allow_cors):
-    settings = Settings(DATA_DIR=directory)
-    app = get_app(settings, allow_cors=allow_cors)
+    settings = Settings(DATA_DIR=directory, ALLOW_CORS=allow_cors)
+    app = get_app(settings)
     uvicorn.run(app, host=host, port=port, log_level="info")

--- a/server/movici_viewer/settings.py
+++ b/server/movici_viewer/settings.py
@@ -7,6 +7,7 @@ class Settings(BaseSettings):
     DATA_DIR: t.Optional[DirectoryPath] = None
     USE_GLOBAL_PLUGINS: bool = True
     VALIDATE_UPDATES: bool = False
+    ALLOW_CORS: bool = False
 
     class Config:
         env_prefix = "MOVICI_FLOW_"


### PR DESCRIPTION
Describe your changes
--------------------
We have an operational mode "allow_cors" that prevents having to use a cors plugin when running `npm run dev` for client development. However, this was not enabled by default when running the `run-devel` Make command for running a development server. This PR adds this support by leveraging the  Settings object so that we can supply the flag that activates this mode as an environment variable

Copyright license
-----------------

Please tick the following box:
 - [x] I hereby grant a full copyright license to NGinfra to use my contribution. This includes but
 is not limited to permission to use my contribution in a commercial setting and to 
 re-/sublicense my contribution
