### PR TITLE
Read baseurl from env instead of static setttings.json

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,13 +22,19 @@ init: pre-init ui
 	&& poetry install --extras dev
 
 data_dir=tests/data
+port=5000
+
 export data_dir
+export port
 
 run-devel:
 	cd server \
 	&& MOVICI_FLOW_DATA_DIR=$(data_dir) \
 	   MOVICI_FLOW_ALLOW_CORS=1 \
-	   poetry run uvicorn --factory movici_viewer.main:get_app --host localhost --port 5000 --reload
+	   poetry run uvicorn --factory movici_viewer.main:get_app --host localhost --port $(port) --reload
 
+run-client:
+	cd client \
+	&& VITE_MOVICI_BASE_URL=http://localhost:$(port) npm run dev
 run:
 	cd server && poetry run movici-viewer

--- a/README.md
+++ b/README.md
@@ -87,12 +87,9 @@ for client development, run the local api server and a Vue development server se
 make run-devel
 ```
 
-Then, change the `"baseURL"` in `client/public/static/settings/settings.json` to the address of
-the local development server, eg: `"http://localhost:5000/"`. Be sure **NOT** to commit this change.
-
 Then, in a separate terminal run the following command:
 
 ```
-npm run --prefix client dev
+make run-client
 ```
 

--- a/client/public/static/settings/settings.json
+++ b/client/public/static/settings/settings.json
@@ -1,5 +1,0 @@
-{
-  "baseURL": "",
-  "features": [],
-  "projections": {}
-}

--- a/client/src/api/requests/index.ts
+++ b/client/src/api/requests/index.ts
@@ -1,5 +1,4 @@
 export * from "./datasets";
-export * from "./general";
 export * from "./scenarios";
 export * from "./summary";
 export * from "./updates";

--- a/client/src/stores/main.ts
+++ b/client/src/stores/main.ts
@@ -1,4 +1,3 @@
-import { GetGlobalSettings } from "@/api/requests";
 import { defaultClient } from "@movici-flow-lib/api/client";
 import type { IClient } from "@movici-flow-lib/types";
 import { global } from "@/i18n";
@@ -23,21 +22,11 @@ export const useMainStore = defineStore("main", () => {
   const settingsStore = useSettingsStore();
   const { failMessage } = useSnackbar();
 
-  async function loadRemoteSettings() {
-    const remoteSettings = await client.value.request(new GetGlobalSettings());
-    if (!remoteSettings) {
-      console.warn("could not load remote settings");
-      return;
-    }
-    settingsStore.update(remoteSettings);
-  }
-
   return {
     initialized,
     client,
     async initializeApp() {
       settingsStore.loadLocal();
-      await loadRemoteSettings();
 
       global.locale.value = settingsStore.locale;
       client.value.baseURL = settingsStore.baseURL;

--- a/client/src/stores/settings.ts
+++ b/client/src/stores/settings.ts
@@ -10,7 +10,7 @@ interface ApplicationSettings {
 
 const defaultSettings: ApplicationSettings = {
   locale: "en",
-  baseURL: "/",
+  baseURL: import.meta.env.VITE_MOVICI_BASE_URL || "/",
   features: [],
   projections: {},
 };


### PR DESCRIPTION
Describe your changes
--------------------

When developing movici viewer, you often have a separate backend and fronten serving process running. In order to point the frontend to the correct backend, it was necessary to edit `client/public/static/settings/settings.json`. However, those changes should not be committed, but it was difficult to enforce this.

Now instead of relying on that file, we read the baseURL pointing to the server process from an environment variable `VITE_MOVICI_BASE_URL`. When set, this variable sets the base url in the movici-viewer client.

This PR also introduces a Makefile command `run-client` that sets this variable appropriately

Copyright license
-----------------

Please tick the following box:
 - [x] I hereby grant a full copyright license to NGinfra to use my contribution. This includes but
 is not limited to permission to use my contribution in a commercial setting and to 
 re-/sublicense my contribution
