### PR TITLE
Support running as python -m movici_viewer

### DIFF
--- a/server/movici_viewer/__main__.py
+++ b/server/movici_viewer/__main__.py
@@ -1,3 +1,4 @@
+import sys
 import typing as t
 from pathlib import Path
 
@@ -60,3 +61,7 @@ def main(directory, host, port, allow_cors):
     settings = Settings(DATA_DIR=directory, ALLOW_CORS=allow_cors)
     app = get_app(settings)
     uvicorn.run(app, host=host, port=port, log_level="info")
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -52,7 +52,7 @@ dev = ["pytest", "httpx", "ruff", "taplo"]
 include = [{ path = "movici_viewer/ui/**/*", format = ["sdist", "wheel"] }]
 
 [tool.poetry.scripts]
-movici-viewer = "movici_viewer.main:main"
+movici-viewer = "movici_viewer.__main__:main"
 
 [tool.ruff]
 line-length = 99

--- a/server/tests/conftest.py
+++ b/server/tests/conftest.py
@@ -6,8 +6,8 @@ from fastapi.testclient import TestClient
 from movici_simulation_core import AttributeSchema, AttributeSpec
 
 from movici_viewer import dependencies
+from movici_viewer.__main__ import get_app
 from movici_viewer.caching import cache_clear
-from movici_viewer.main import get_app
 from movici_viewer.settings import Settings
 
 


### PR DESCRIPTION
Describe your changes
--------------------
This PR adds support to run movici-viewer using `python -m movici_viewer`. In addition to providing a better UX, this also makes it easier to attach a debugger to movici-viewer (such as VSCode pyright)

Copyright license
-----------------

Please tick the following box:
 - [x] I hereby grant a full copyright license to NGinfra to use my contribution. This includes but
 is not limited to permission to use my contribution in a commercial setting and to 
 re-/sublicense my contribution
